### PR TITLE
feat: added test compile code for squire desktop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,21 +10,21 @@ if(ENABLE_LTO)
     set(RUST_FLAGS "-Clinker-plugin-lto" "-Clinker=clang-13" "-Clink-arg=-fuse-ld=lld")
 endif()
 
-set(RUST_PART_LIB "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/librust_part.a")
+set(RUST_PART_LIB "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libsquire_core.a")
 
 set(RUST_PART_CXX "${CMAKE_CURRENT_BINARY_DIR}/squire_core.cpp")
 add_library(squire_core STATIC ${RUST_PART_CXX})
 add_custom_command(
     OUTPUT ${RUST_PART_CXX}
     COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} RUSTFLAGS="${RUST_FLAGS}" ${CARGO_CMD}
-    COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/rust_part/src/lib.rs.cc ${RUST_PART_CXX}
-    COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/rust_part/src/lib.rs.h ${CMAKE_CURRENT_BINARY_DIR}/rust_part.h
+    COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/squire_core/src/lib.rs.cc ${RUST_PART_CXX}
+    COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/squire_core/src/lib.rs.h ${CMAKE_CURRENT_BINARY_DIR}/rust_part.h
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(squire_core pthread dl ${RUST_PART_LIB})
 
-add_test(NAME squire_core_test 
+add_test(NAME squire_core_test
     COMMAND cargo test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,11 @@ dashmap = { version = "5.0", features = ["serde"] }
 #dotenv = { version = "0.9.0" }
 #env_logger = { version = "0.6" }
 #futures = { version = "0.1" }
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"
+
+[lib]
+crate-type = ["staticlib"]
+

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let _build = cxx_build::bridge("src/lib.rs");
+
+    println!("cargo:rerun-if-changed=src/lib.rs");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,16 @@
 #![allow(dead_code, unused_variables, unused_imports, unused_import_braces)]
+#[cxx::bridge]
+mod sample {
+  #[namespace = "squire_core"]
+  extern "Rust" {
+    fn func(a: i32) -> i32;
+  }
+}
+
+fn func(a: i32) -> i32 {
+    a + 3
+}
+
 pub mod error;
 pub mod fluid_pairings;
 pub mod game;
@@ -15,3 +27,4 @@ pub mod tournament_registry;
 pub mod utils;
 pub mod settings;
 pub mod consts;
+


### PR DESCRIPTION
This adds the sample `mod` with a test func for compile testing. It needs to be rewritten to have the contents of the squire core defined in an `extern "Rust"` block for each `mod`. However this is a good proof of concept for the cxx bridge in the mean time.