### PR TITLE
Deterministic Tournament Operations

### DIFF
--- a/squire_lib/Cargo.toml
+++ b/squire_lib/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["TylerBloom <tylerbloom2222@gmail.com>"]
 crate-type = ["lib", "staticlib"]
 
 [features]
-#default = ["deck_sites"]
-default = ["ffi", "mtgjson/deck_sites"]
+default = ["deck_sites"]
+#default = ["ffi", "mtgjson/deck_sites"]
 deck_sites = ["mtgjson/deck_sites"]
 ffi = ["cbindgen", "libc"]
 wasm = ["chrono/wasmbind"]
@@ -22,7 +22,8 @@ mtgjson = { git = "https://github.com/TylerBloom/mtgjson-rust-sdk", rev="864d710
 # mtgjson = { path = "../mtgjson-rust-sdk", features = ["deck_sites"] }
 lazy_static = "1.4.0"
 
-uuid = { version = "1.1", features = ["serde", "v4"] }
+deterministic-hash = { version = "1.0" }
+uuid = { version = "1.1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.68" }
 once_cell = { version = "1.8.0" }

--- a/squire_lib/src/accounts.rs
+++ b/squire_lib/src/accounts.rs
@@ -1,5 +1,6 @@
+use deterministic_hash::DeterministicHasher;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, hash::Hash};
+use std::{collections::{HashMap, hash_map::DefaultHasher}, hash::{Hash, Hasher}};
 use uuid::Uuid;
 
 use crate::{
@@ -78,11 +79,16 @@ pub struct OrganizationAccount {
 impl SquireAccount {
     /// Creates a new SquireAccount with associated data
     pub fn new(user_name: String, display_name: String) -> Self {
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        user_name.hash(&mut hasher);
+        let upper = hasher.finish();
+        display_name.hash(&mut hasher);
+        let lower = hasher.finish();
         SquireAccount {
             display_name,
             user_name,
             gamer_tags: HashMap::new(),
-            user_id: Uuid::new_v4().into(),
+            user_id: Uuid::from_u64_pair(upper, lower).into(),
             permissions: SharingPermissions::default(),
         }
     }
@@ -166,11 +172,16 @@ impl SquireAccount {
 impl OrganizationAccount {
     /// Creates a new account object
     pub fn new(owner: SquireAccount, org_name: String, display_name: String) -> Self {
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        org_name.hash(&mut hasher);
+        let upper = hasher.finish();
+        display_name.hash(&mut hasher);
+        let lower = hasher.finish();
         Self {
             owner,
             org_name,
             display_name,
-            account_id: Uuid::new_v4().into(),
+            account_id: Uuid::from_u64_pair(upper, lower).into(),
             default_judges: HashMap::new(),
             default_admins: HashMap::new(),
             default_tournament_settings: TournamentSettingsTree::new(),

--- a/squire_lib/src/identifiers.rs
+++ b/squire_lib/src/identifiers.rs
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn basic_serde() {
-        let id = Uuid::new_v4();
+        let id = Uuid::default();
         let p_id: PlayerId = id.into();
         assert_eq!(
             serde_json::to_string(&id).unwrap(),
@@ -185,7 +185,7 @@ mod tests {
         let mut map: HashMap<AdminId, Admin> = HashMap::new();
         let admin = Admin {
             name: "Test".into(),
-            id: Uuid::new_v4().into(),
+            id: Uuid::default().into(),
         };
         let id = admin.id;
         map.insert(id, admin);

--- a/squire_lib/src/operations/admin_ops.rs
+++ b/squire_lib/src/operations/admin_ops.rs
@@ -4,7 +4,7 @@ use crate::{
     accounts::SquireAccount,
     identifiers::{PlayerId, RoundId},
     rounds::RoundResult,
-    settings::TournamentSetting,
+    settings::TournamentSetting, pairings::Pairings,
 };
 
 /// Operations that only tournament admin can perform
@@ -39,7 +39,9 @@ pub enum AdminOp {
     /// Operation to manually create a round
     CreateRound(Vec<PlayerId>),
     /// Operation to attempt to pair the next set of rounds
-    PairRound,
+    CreatePairings,
+    /// Operation to attempt to pair the next set of rounds
+    PairRound(Pairings),
     /// Operation to cut to the top N players (by standings)
     Cut(usize),
     /// Operation to prune excess decks from players

--- a/squire_lib/src/operations/mod.rs
+++ b/squire_lib/src/operations/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     error::TournamentError,
     identifiers::{AdminId, OpId, PlayerId},
     rounds::{RoundId, RoundStatus},
-    tournament::TournamentPreset,
+    tournament::TournamentPreset, pairings::Pairings,
 };
 
 mod admin_ops;
@@ -51,6 +51,8 @@ pub enum OpData {
     GiveBye(RoundId),
     /// A round was manually created and this is that round's id
     CreateRound(RoundId),
+    /// The pairings for the next set of rounds
+    CreatePairings(Pairings),
     /// The next set of rounds was paired and these are those round's ids
     Pair(Vec<RoundId>),
 }
@@ -590,7 +592,7 @@ impl OpData {
     pub fn assume_nothing(self) {
         match self {
             Self::Nothing => (),
-            _ => panic!("Assumed OpData nothing failed"),
+            _ => panic!("Assumed OpData was nothing, failed"),
         }
     }
 
@@ -600,7 +602,7 @@ impl OpData {
     pub fn assume_register_player(self) -> PlayerId {
         match self {
             Self::RegisterPlayer(id) => id,
-            _ => panic!("Assumed OpData was register player failed"),
+            _ => panic!("Assumed OpData was register player, failed"),
         }
     }
 
@@ -610,7 +612,7 @@ impl OpData {
     pub fn assume_register_judge(self) -> Judge {
         match self {
             Self::RegisterJudge(judge) => judge,
-            _ => panic!("Assumed OpData was register judge failed"),
+            _ => panic!("Assumed OpData was register judge, failed"),
         }
     }
 
@@ -620,7 +622,7 @@ impl OpData {
     pub fn assume_register_admin(self) -> Admin {
         match self {
             Self::RegisterAdmin(admin) => admin,
-            _ => panic!("Assumed OpData was register admin failed"),
+            _ => panic!("Assumed OpData was register admin, failed"),
         }
     }
 
@@ -630,7 +632,7 @@ impl OpData {
     pub fn assume_confirm_result(self) -> (RoundId, RoundStatus) {
         match self {
             Self::ConfirmResult(r_id, status) => (r_id, status),
-            _ => panic!("Assumed OpData was confirm result failed"),
+            _ => panic!("Assumed OpData was confirm result, failed"),
         }
     }
 
@@ -640,7 +642,7 @@ impl OpData {
     pub fn assume_give_bye(self) -> RoundId {
         match self {
             Self::GiveBye(id) => id,
-            _ => panic!("Assumed OpData was give bye failed"),
+            _ => panic!("Assumed OpData was give bye, failed"),
         }
     }
 
@@ -650,7 +652,17 @@ impl OpData {
     pub fn assume_create_round(self) -> RoundId {
         match self {
             Self::CreateRound(id) => id,
-            _ => panic!("Assumed OpData was create round failed"),
+            _ => panic!("Assumed OpData was create round, failed"),
+        }
+    }
+
+    /// Assumes contained data is from `Pair` and returns that id, analogous to `unwrap`.
+    ///
+    /// PANICS: If the data is anything else, this method panics.
+    pub fn assume_create_pairings(self) -> Pairings {
+        match self {
+            Self::CreatePairings(pairings) => pairings,
+            _ => panic!("Assumed OpData was CreatePairings, failed."),
         }
     }
 
@@ -660,7 +672,7 @@ impl OpData {
     pub fn assume_pair(self) -> Vec<RoundId> {
         match self {
             Self::Pair(ids) => ids,
-            _ => panic!("Assumed OpData was pair round failed"),
+            _ => panic!("Assumed OpData was pair round, failed"),
         }
     }
 }

--- a/squire_lib/src/operations/mod.rs
+++ b/squire_lib/src/operations/mod.rs
@@ -1,4 +1,7 @@
+use std::{collections::hash_map::DefaultHasher, hash::{Hash, Hasher}};
+
 use chrono::{DateTime, Utc};
+use deterministic_hash::DeterministicHasher;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -496,10 +499,16 @@ impl From<OpSync> for SyncStatus {
 impl FullOp {
     /// Creates a new FullOp from an existing TournOp
     pub fn new(op: TournOp) -> Self {
+        let now = Utc::now();
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        now.hash(&mut hasher);
+        let upper = hasher.finish();
+        upper.hash(&mut hasher);
+        let lower = hasher.finish();
         Self {
             op,
-            id: OpId::new(Uuid::new_v4()),
-            salt: Utc::now(),
+            id: OpId::new(Uuid::from_u64_pair(upper, lower)),
+            salt: now,
             active: true,
         }
     }

--- a/squire_lib/src/pairings/branching.rs
+++ b/squire_lib/src/pairings/branching.rs
@@ -107,10 +107,10 @@ mod tests {
     #[test]
     fn simple_tree() {
         let ids = vec![
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
+            PlayerId::new(Uuid::from_u128(0)),
+            PlayerId::new(Uuid::from_u128(1)),
+            PlayerId::new(Uuid::from_u128(2)),
+            PlayerId::new(Uuid::from_u128(3)),
         ];
 
         let opps: HashMap<PlayerId, HashSet<PlayerId>> =
@@ -149,11 +149,11 @@ mod tests {
     #[test]
     fn single_branch() {
         let ids = vec![
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
+            PlayerId::new(Uuid::from_u128(0)),
+            PlayerId::new(Uuid::from_u128(1)),
+            PlayerId::new(Uuid::from_u128(2)),
+            PlayerId::new(Uuid::from_u128(3)),
+            PlayerId::new(Uuid::from_u128(4)),
         ];
 
         let mut opps: HashMap<PlayerId, HashSet<PlayerId>> =
@@ -205,11 +205,11 @@ mod tests {
     #[test]
     fn triple_branch() {
         let ids = vec![
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
-            PlayerId::new(Uuid::new_v4()),
+            PlayerId::new(Uuid::from_u128(0)),
+            PlayerId::new(Uuid::from_u128(1)),
+            PlayerId::new(Uuid::from_u128(2)),
+            PlayerId::new(Uuid::from_u128(3)),
+            PlayerId::new(Uuid::from_u128(4)),
         ];
 
         let mut opps: HashMap<PlayerId, HashSet<PlayerId>> =

--- a/squire_lib/src/pairings/mod.rs
+++ b/squire_lib/src/pairings/mod.rs
@@ -34,7 +34,7 @@ pub use greedy::greedy_pairings;
 pub use rotary::rotary_pairings;
 pub use swiss_pairings::SwissPairings;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 /// A struct for communicating new pairings information
 pub struct Pairings {
     /// The players that are paired and their groupings

--- a/squire_lib/src/pairings/mod.rs
+++ b/squire_lib/src/pairings/mod.rs
@@ -44,7 +44,7 @@ pub struct Pairings {
 }
 
 /// Encodes what algorithm will be used to pair players
-#[derive(Serialize, Deserialize, Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Hash, Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PairingAlgorithm {
     /// This variant corresponds to the `greedy_pairings` function
     Greedy,

--- a/squire_lib/src/players/mod.rs
+++ b/squire_lib/src/players/mod.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, fmt::Display};
+use std::{collections::{HashMap, hash_map::DefaultHasher}, fmt::Display, hash::{Hash, Hasher}};
 
+use deterministic_hash::DeterministicHasher;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -46,8 +47,13 @@ pub struct Player {
 impl Player {
     /// Creates a new player
     pub fn new(name: String) -> Self {
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        name.hash(&mut hasher);
+        let upper = hasher.finish();
+        upper.hash(&mut hasher);
+        let lower = hasher.finish();
         Player {
-            id: Uuid::new_v4().into(),
+            id: Uuid::from_u64_pair(upper, lower).into(),
             name,
             game_name: None,
             deck_ordering: Vec::new(),

--- a/squire_lib/src/rounds/mod.rs
+++ b/squire_lib/src/rounds/mod.rs
@@ -1,11 +1,12 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::DefaultHasher},
     fmt,
-    time::Duration,
+    time::Duration, hash::{Hash, Hasher},
 };
 
 use chrono::{DateTime, Utc};
 
+use deterministic_hash::DeterministicHasher;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -84,8 +85,11 @@ pub struct Round {
 impl Round {
     /// Creates a new round
     pub fn new(match_num: u64, table_number: u64, len: Duration) -> Self {
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        len.hash(&mut hasher);
+        let lower = hasher.finish();
         Round {
-            id: RoundId::new(Uuid::new_v4()),
+            id: RoundId::new(Uuid::from_u64_pair(match_num, lower)),
             match_number: match_num,
             table_number,
             players: HashSet::with_capacity(4),

--- a/squire_lib/src/rounds/round_registry.rs
+++ b/squire_lib/src/rounds/round_registry.rs
@@ -243,7 +243,7 @@ mod tests {
         let id_one = reg.create_round();
         assert!(reg.num_and_id.contains_right(&id_one));
         assert!(reg.rounds.contains_key(&id_one));
-        let id_two = Uuid::new_v4().into();
+        let id_two = Uuid::default().into();
         assert!(reg.update_id(id_one, id_two));
         assert!(!reg.num_and_id.contains_right(&id_one));
         assert!(!reg.rounds.contains_key(&id_one));

--- a/squire_lib/src/settings.rs
+++ b/squire_lib/src/settings.rs
@@ -72,7 +72,7 @@ pub struct PairingSettingsTree {
     pub fluid: FluidPairingsSettingsTree,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
 /// An enum that encodes all the adjustable settings of all pairing systems
 pub enum PairingSetting {
     /// Adjusts the number of players that will be in a match
@@ -109,19 +109,19 @@ pub struct SwissPairingsSettingsTree {
     pub do_check_ins: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
+#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
 /// An enum that encodes all the adjustable settings of swiss pairing systems
 pub enum SwissPairingsSetting {
     /// Whether or not player need to check in before a round is paired
     DoCheckIns(bool),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Hash, Clone, PartialEq, Eq)]
 /// A set of adjustable default settings for a fluid pairing system.
 pub struct FluidPairingsSettingsTree {}
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
 /// An enum that encodes all the adjustable settings of fluid pairing systems
 pub enum FluidPairingsSetting {}
 
@@ -158,8 +158,8 @@ pub struct StandardScoringSettingsTree {
     pub include_opp_gwp: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[repr(C)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 /// An enum that encodes all the adjustable settings of standard scoring systems
 pub enum StandardScoringSetting {
     /// Adjusts the number of points a match win is worth

--- a/squire_lib/tests/determinism.rs
+++ b/squire_lib/tests/determinism.rs
@@ -71,12 +71,18 @@ mod tests {
             .assume_nothing();
         tourn_two.apply_op(now, op).unwrap().assume_nothing();
         // Pair the first round
-        println!("Pairing first round");
+        println!("Creating first pairings");
         let now = Utc::now();
-        let op = TournOp::AdminOp(a_id, AdminOp::PairRound);
-        let r_id_one = tourn_one.apply_op(now, op.clone()).unwrap().assume_pair();
-        let r_id_two = tourn_two.apply_op(now, op).unwrap().assume_pair();
-        assert_eq!(r_id_one, r_id_two);
+        let op = TournOp::AdminOp(a_id, AdminOp::CreatePairings);
+        let pairings = tourn_one.apply_op(now, op.clone()).unwrap().assume_create_pairings();
+        let _ = tourn_two.apply_op(now, op).unwrap().assume_create_pairings();
+        assert_eq!(tourn_one, tourn_two);
+        println!("Creating rounds");
+        let now = Utc::now();
+        let op = TournOp::AdminOp(a_id, AdminOp::PairRound(pairings));
+        let rnds_one = tourn_one.apply_op(now, op.clone()).unwrap().assume_pair();
+        let rnds_two = tourn_two.apply_op(now, op).unwrap().assume_pair();
+        assert_eq!(rnds_one, rnds_two);
         assert_eq!(tourn_one, tourn_two);
     }
 }

--- a/squire_lib/tests/determinism.rs
+++ b/squire_lib/tests/determinism.rs
@@ -1,6 +1,15 @@
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+        str::FromStr,
+    };
+
+    use chrono::{DateTime, Utc};
+    use deterministic_hash::DeterministicHasher;
+    use uuid::Uuid;
+    
     use squire_lib::{
         accounts::SquireAccount,
         identifiers::AdminId,
@@ -8,6 +17,45 @@ mod tests {
         settings::{PairingSetting, TournamentSetting},
         tournament::TournamentPreset,
     };
+
+    // NOTE: While we can't test different architectures on the same machine, this is controlled
+    // for in CI
+    #[test]
+    fn consistant_hashing() {
+        let mut now_and_id_hasher = DeterministicHasher::new(DefaultHasher::new());
+        let mut now_and_vec_hasher = DefaultHasher::new();
+        // Hash a timestamp
+        let mut hasher = DefaultHasher::new();
+        let now: DateTime<Utc> = DateTime::from_str("2022-11-06 01:10:43.945027291 UTC").unwrap();
+        now.hash(&mut hasher);
+        now.hash(&mut now_and_id_hasher);
+        now.hash(&mut now_and_vec_hasher);
+        let hash = hasher.finish();
+        assert_eq!(hash, 6743072779167678941);
+        // Hash a single id
+        let mut hasher = DefaultHasher::new();
+        let id = Uuid::from_str("14a0544b-d4a4-4056-a1c0-6905db264ecf").unwrap();
+        id.hash(&mut hasher);
+        id.hash(&mut now_and_id_hasher);
+        let hash = hasher.finish();
+        let now_and_id_hash = hasher.finish();
+        assert_eq!(hash, 12099548975201988587);
+        assert_eq!(now_and_id_hash, 12099548975201988587);
+        // Hash a vec of ids
+        let mut hasher = DefaultHasher::new();
+        let ids = vec![
+            Uuid::from_str("ea476c0c-8d58-4429-8a9e-5e719c000d7a").unwrap(),
+            Uuid::from_str("6d306232-44a0-4bf1-b971-d8d77bccb754").unwrap(),
+            Uuid::from_str("7a00ca44-7ab8-4b93-a068-29bbf7e1a3fb").unwrap(),
+            Uuid::from_str("22103c9e-58c3-4143-9e70-bff4f531ad89").unwrap(),
+        ];
+        ids.hash(&mut hasher);
+        ids.hash(&mut now_and_vec_hasher);
+        let hash = hasher.finish();
+        let now_and_vec_hash = hasher.finish();
+        assert_eq!(hash, 10483062192994910974);
+        assert_eq!(now_and_vec_hash, 10483062192994910974);
+    }
 
     #[test]
     fn basic_determinism() {
@@ -74,8 +122,14 @@ mod tests {
         println!("Creating first pairings");
         let now = Utc::now();
         let op = TournOp::AdminOp(a_id, AdminOp::CreatePairings);
-        let pairings = tourn_one.apply_op(now, op.clone()).unwrap().assume_create_pairings();
-        let _ = tourn_two.apply_op(now, op).unwrap().assume_create_pairings();
+        let pairings = tourn_one
+            .apply_op(now, op.clone())
+            .unwrap()
+            .assume_create_pairings();
+        let _ = tourn_two
+            .apply_op(now, op)
+            .unwrap()
+            .assume_create_pairings();
         assert_eq!(tourn_one, tourn_two);
         println!("Creating rounds");
         let now = Utc::now();

--- a/squire_lib/tests/fluid_pairings.rs
+++ b/squire_lib/tests/fluid_pairings.rs
@@ -1,10 +1,11 @@
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, time::Duration};
+    use std::{collections::{HashMap, hash_map::DefaultHasher}, time::Duration, hash::{Hash, Hasher}};
 
+    use chrono::Utc;
+    use deterministic_hash::DeterministicHasher;
     use squire_lib::{
         accounts::{SharingPermissions, SquireAccount},
-        identifiers::UserAccountId,
         pairings::PairingSystem,
         players::PlayerRegistry,
         rounds::RoundRegistry,
@@ -14,12 +15,18 @@ mod tests {
     use uuid::Uuid;
 
     fn spoof_account() -> SquireAccount {
-        let id: UserAccountId = Uuid::new_v4().into();
+        let now = Utc::now();
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        now.hash(&mut hasher);
+        let upper = hasher.finish();
+        upper.hash(&mut hasher);
+        let lower = hasher.finish();
+        let id = Uuid::from_u64_pair(upper, lower);
         SquireAccount {
             user_name: id.to_string(),
             display_name: id.to_string(),
             gamer_tags: HashMap::new(),
-            user_id: id,
+            user_id: id.into(),
             permissions: SharingPermissions::Everything,
         }
     }

--- a/squire_lib/tests/registration.rs
+++ b/squire_lib/tests/registration.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::{HashMap, hash_map::DefaultHasher}, hash::{Hash, Hasher}};
 
+    use chrono::Utc;
+    use deterministic_hash::DeterministicHasher;
     use squire_lib::{
         accounts::{SharingPermissions, SquireAccount},
         identifiers::AdminId,
@@ -11,7 +13,13 @@ mod tests {
     use uuid::Uuid;
 
     fn spoof_account() -> SquireAccount {
-        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        now.hash(&mut hasher);
+        let upper = hasher.finish();
+        upper.hash(&mut hasher);
+        let lower = hasher.finish();
+        let id = Uuid::from_u64_pair(upper, lower);
         SquireAccount {
             user_name: id.to_string(),
             display_name: id.to_string(),

--- a/squire_lib/tests/settings.rs
+++ b/squire_lib/tests/settings.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::{HashMap, hash_map::DefaultHasher}, hash::{Hash, Hasher}};
 
+    use chrono::Utc;
+    use deterministic_hash::DeterministicHasher;
     use squire_lib::{
         accounts::{SharingPermissions, SquireAccount},
         error::TournamentError,
@@ -13,7 +15,13 @@ mod tests {
     use uuid::Uuid;
 
     fn spoof_account() -> SquireAccount {
-        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        now.hash(&mut hasher);
+        let upper = hasher.finish();
+        upper.hash(&mut hasher);
+        let lower = hasher.finish();
+        let id = Uuid::from_u64_pair(upper, lower);
         SquireAccount {
             user_name: id.to_string(),
             display_name: id.to_string(),

--- a/squire_lib/tests/swiss_pairings.rs
+++ b/squire_lib/tests/swiss_pairings.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, time::Duration};
+    use std::{collections::{HashMap, hash_map::DefaultHasher}, time::Duration, hash::{Hash, Hasher}};
+    use chrono::Utc;
+    use deterministic_hash::DeterministicHasher;
     use uuid::Uuid;
 
     use squire_lib::{
         accounts::{SharingPermissions, SquireAccount},
-        identifiers::UserAccountId,
         pairings::PairingSystem,
         players::PlayerRegistry,
         rounds::{RoundRegistry, RoundResult},
@@ -15,12 +16,18 @@ mod tests {
     };
 
     fn spoof_account() -> SquireAccount {
-        let id: UserAccountId = Uuid::new_v4().into();
+        let now = Utc::now();
+        let mut hasher = DeterministicHasher::new(DefaultHasher::new());
+        now.hash(&mut hasher);
+        let upper = hasher.finish();
+        upper.hash(&mut hasher);
+        let lower = hasher.finish();
+        let id = Uuid::from_u64_pair(upper, lower);
         SquireAccount {
             user_name: id.to_string(),
             display_name: id.to_string(),
             gamer_tags: HashMap::new(),
-            user_id: id,
+            user_id: id.into(),
             permissions: SharingPermissions::Everything,
         }
     }

--- a/squire_lib/tests/utils.rs
+++ b/squire_lib/tests/utils.rs
@@ -1,5 +1,6 @@
 use squire_lib::players::Player;
 
 pub fn spoof_player() -> Player {
-    Player::new(uuid::Uuid::new_v4().to_string())
+    //Player::new(uuid::Uuid::new_v4().to_string())
+    todo!()
 }


### PR DESCRIPTION
The tournament sync process requires mostly deterministic operations. Any non-determinism must be captured and returned by the operation. For example, the creation of pairings can be non-deterministic. However, this requires the pairings to be returned immediately after. If the operations for creating pairings included creating the pairings and pairings the rounds, different pair round operations would yield different things.

Currently, there are four operations that cause concerns for non-determinism:
  - Register guest,
  - Give bye
  - Create round
  - Pair Round
 
All of these operations could be non-deterministic because they involve the creation `Uuid`s. This is addressed via adding "salt" to the operations (e.g. a timestamp). However, the hasher used to generate ids much be deterministic and produce the same ids across all targetted platforms.

There is one expressly non-deterministic operation, create pairings. This operation should probably not be an operation and rather be a query into the tournament. This would require accessing the pairing system immutability to create pairings, which could be a concern for fluid pairings. This will likely require some work arounds.