### PR TITLE
Update tournament.rs

### DIFF
--- a/squire_lib/src/error.rs
+++ b/squire_lib/src/error.rs
@@ -69,6 +69,7 @@ impl fmt::Display for TournamentError {
             InvalidDeckCount => "InvalidDeckCount",
             RoundConfirmed => "RoundConfirmed",
             NoMatchResult => "NoMatchResult",
+            MaxDecksReached => "MaxDecksReached",
         };
         write!(f, "{s}")
     }

--- a/squire_lib/src/error.rs
+++ b/squire_lib/src/error.rs
@@ -43,6 +43,8 @@ pub enum TournamentError {
     InvalidDeckCount,
     /// There is at least one active match without a result
     NoMatchResult,
+    /// A player already had the max number of decks
+    MaxDecksReached,
 }
 
 impl fmt::Display for TournamentError {

--- a/squire_lib/src/operations/admin_ops.rs
+++ b/squire_lib/src/operations/admin_ops.rs
@@ -45,8 +45,6 @@ pub enum AdminOp {
     PairRound(Pairings),
     /// Operation to cut to the top N players (by standings)
     Cut(usize),
-    /// Operation to prune excess decks from players
-    PruneDecks,
     /// Operation to prune players that aren't fully registered
     PrunePlayers,
     /// Operation to confirm the results of all active rounds

--- a/squire_lib/src/tournament.rs
+++ b/squire_lib/src/tournament.rs
@@ -653,8 +653,8 @@ impl Tournament {
             return Err(TournamentError::RegClosed);
         }
         let p = self.player_reg.get_player(ident)?;
-        if p.decks.len() as u8 >= self.max_deck_count {
-            return Err(TournamentError::InvalidDeckCount);
+        if plyr.decks.len() >= self.max_deck_count as usize {
+            return Err(TournamentError::MaxDecksReached);
         }
         let plyr = self.player_reg.get_mut_player(ident)?;
         plyr.add_deck(name, deck);
@@ -820,6 +820,9 @@ impl Tournament {
             return Err(TournamentError::IncorrectStatus(self.status));
         }
         let plyr = self.player_reg.get_mut_player(&id)?;
+        if plyr.decks.len() >= self.max_deck_count as usize {
+            return Err(TournamentError::MaxDecksReached);
+        }
         plyr.add_deck(name, deck);
         Ok(OpData::Nothing)
     }

--- a/squire_lib/src/tournament.rs
+++ b/squire_lib/src/tournament.rs
@@ -652,7 +652,7 @@ impl Tournament {
         if !self.reg_open {
             return Err(TournamentError::RegClosed);
         }
-        let p = self.player_reg.get_player(ident)?;
+        let plyr = self.player_reg.get_player(ident)?;
         if plyr.decks.len() >= self.max_deck_count as usize {
             return Err(TournamentError::MaxDecksReached);
         }


### PR DESCRIPTION
I've removed the need for TOs to prune decks. Instead, if a player tries to add a deck after the max number is exceeded (default now set to 1) then they get an error. I'm not sure if InvalidDeckCount is the right error message to use though, as that's the same message a TO would get if they try to set the min deck to greater than max or max less than min. 

I'm pretty sure this also means that the PruneDecks stuff from admin_ops.rs can be removed as well. But because I suck at using GitHub I couldn't figure out how to also attach that change to this branch.