### PR TITLE
Fix Coverage CI Job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,12 +25,9 @@ jobs:
         uses: jetli/trunk-action@v0.4.0
         with:
           version: 'latest'
-      - name: Fetch Tarpaulin
+      - name: Fetch and run Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: 'latest'
-      - name: Generate code coverage
-        run: |
-          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+            args: '--verbose --all-features --workspace --timeout 120'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,10 @@ jobs:
         with:
           rust-version: nightly
           targets: wasm32-unknown-unknown
-
+      - name: Fetch Trunk
+        uses: jetli/trunk-action@v0.4.0
+        with:
+          version: 'latest'
       - name: Generate code coverage
         run: |
           cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,10 +25,13 @@ jobs:
         uses: jetli/trunk-action@v0.4.0
         with:
           version: 'latest'
-      - name: Fetch and run Tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - name: Fetch Tarpaulin
+        uses: actions-rs/install@v0.1
         with:
-            version: '0.25.1'
-            args: '--verbose --all-features --workspace --timeout 120'
+          crate: cargo-tarpaulin
+          version: 'latest'
+      - name: Generate code coverage
+        run: |
+          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Fetch and run Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
+            version: '0.25.1'
             args: '--verbose --all-features --workspace --timeout 120'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Squire CI
+name: Squire Coverage
 
 on:
   push:
@@ -13,13 +13,11 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    container:
-      image: xd009642/tarpaulin:develop-nightly
-      options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: hecrj/setup-rust-action@v1
+      - name: Setup Rust
+        uses: hecrj/setup-rust-action@v1
         with:
           rust-version: nightly
           targets: wasm32-unknown-unknown
@@ -27,9 +25,12 @@ jobs:
         uses: jetli/trunk-action@v0.4.0
         with:
           version: 'latest'
+      - name: Fetch Tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: 'latest'
       - name: Generate code coverage
         run: |
           cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
-
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/squire_core_ci.yml
+++ b/.github/workflows/squire_core_ci.yml
@@ -23,8 +23,10 @@ jobs:
           rust-version: ${{ matrix.rust }}
           targets: wasm32-unknown-unknown
       - uses: actions/checkout@v3
-      - run: wget -qO- https://github.com/thedodd/trunk/releases/download/v0.16.0/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
-      - run: pwd >> $GITHUB_PATH
+      - name: Fetch Trunk
+        uses: jetli/trunk-action@v0.4.0
+        with:
+          version: 'latest'
       - run: cargo build --package squire_core --verbose
       - run: cargo test --package squire_core --verbose
       - run: cargo doc --package squire_core --verbose


### PR DESCRIPTION
With the changes to `squire_core`'s build flow (now requiring WASM and trunk), the Coverage CI job as stopped working. This PR addresses that.