### PR TITLE
Deterministic output for `id_from_item`

### DIFF
--- a/squire_lib/Cargo.toml
+++ b/squire_lib/Cargo.toml
@@ -24,6 +24,8 @@ itertools = { version = "0.10.0" }
 num-rational = { version = "0.4.1", features = ["serde"] }
 html-escape = { version = "0.2.12" }
 getrandom = { version = "0.2" }
+deterministic-hash = "=1.0.1"
+fxhash = "=0.2.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/squire_lib/src/identifiers.rs
+++ b/squire_lib/src/identifiers.rs
@@ -7,6 +7,8 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
+use deterministic_hash::DeterministicHasher;
+use fxhash::FxHasher64;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
@@ -23,7 +25,7 @@ pub fn id_from_item<T, ID>(salt: DateTime<Utc>, item: T) -> TypeId<ID>
 where
     T: Hash,
 {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = DeterministicHasher::new(FxHasher64::default());
     salt.hash(&mut hasher);
     let upper = hasher.finish();
     item.hash(&mut hasher);

--- a/squire_lib/src/identifiers.rs
+++ b/squire_lib/src/identifiers.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::Display,
     hash::{Hash, Hasher},
     marker::PhantomData,

--- a/squire_lib/src/identifiers.rs
+++ b/squire_lib/src/identifiers.rs
@@ -3,7 +3,8 @@ use std::{
     fmt::Display,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    ops::Deref, str::FromStr,
+    ops::Deref,
+    str::FromStr,
 };
 
 use chrono::{DateTime, Utc};
@@ -20,12 +21,17 @@ use crate::{
     tournament::Tournament,
 };
 
+#[inline(always)]
+fn id_hasher() -> DeterministicHasher<FxHasher64> {
+    DeterministicHasher::new(FxHasher64::default())
+}
+
 /// Creates an ID (of any type) from a time and a hashable value
 pub fn id_from_item<T, ID>(salt: DateTime<Utc>, item: T) -> TypeId<ID>
 where
     T: Hash,
 {
-    let mut hasher = DeterministicHasher::new(FxHasher64::default());
+    let mut hasher = id_hasher();
     salt.hash(&mut hasher);
     let upper = hasher.finish();
     item.hash(&mut hasher);
@@ -39,7 +45,7 @@ where
     I: Iterator<Item = T>,
     T: Hash,
 {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = id_hasher();
     salt.hash(&mut hasher);
     let upper = hasher.finish();
     for item in vals {

--- a/squire_lib/tests/determinism.rs
+++ b/squire_lib/tests/determinism.rs
@@ -79,20 +79,28 @@ mod tests {
         assert_eq!(tourn_one, tourn_two);
     }
 
+    type HashDeterminismCase = (DateTime<Utc>, Vec<u64>, TypeId<()>, TypeId<()>);
+
     /// Independently tests `squire_lib::identifiers::id_from_item` for consistent behavior across
     /// platforms. Expected data is based off of linux.
     #[test]
     fn hash_determinism() {
-        let test_data: Vec<(DateTime<Utc>, Vec<u64>, TypeId<()>)> = serde_json::from_slice(
+        let test_data: Vec<HashDeterminismCase> = serde_json::from_slice(
             include_bytes!("./determinism/deterministic_uuid_test_cases.json"),
         )
         .expect("Could not parse test cases");
 
-        for (timestamp, payload, expected_hash) in test_data {
+        for (timestamp, payload, expected_hash_item, expected_hash_list) in test_data {
+            assert_eq!(
+                squire_lib::identifiers::id_from_list(timestamp, payload.iter()),
+                expected_hash_list,
+                "Wrong hash emitted by `id_from_list`"
+            );
             assert_eq!(
                 squire_lib::identifiers::id_from_item(timestamp, payload),
-                expected_hash
-            )
+                expected_hash_item,
+                "Wrong hash emitted by `id_from_item`"
+            );
         }
     }
 }

--- a/squire_lib/tests/determinism.rs
+++ b/squire_lib/tests/determinism.rs
@@ -79,17 +79,20 @@ mod tests {
         assert_eq!(tourn_one, tourn_two);
     }
 
-    const DATA_HASH_PAIRS: &[(DateTime<Utc>, &[u8], TypeId<()>)] = &[];
-
     /// Independently tests `squire_lib::identifiers::id_from_item` for consistent behavior across
-    /// platforms.
+    /// platforms. Expected data is based off of linux.
     #[test]
     fn hash_determinism() {
-        for &(salt, item, test_hash) in std::hint::black_box(DATA_HASH_PAIRS) {
+        let test_data: Vec<(DateTime<Utc>, Vec<u64>, TypeId<()>)> = serde_json::from_slice(
+            include_bytes!("./determinism/deterministic_uuid_test_cases.json"),
+        )
+        .expect("Could not parse test cases");
+
+        for (timestamp, payload, expected_hash) in test_data {
             assert_eq!(
-                std::hint::black_box(squire_lib::identifiers::id_from_item(salt, item)),
-                test_hash
-            );
+                squire_lib::identifiers::id_from_item(timestamp, payload),
+                expected_hash
+            )
         }
     }
 }

--- a/squire_lib/tests/determinism.rs
+++ b/squire_lib/tests/determinism.rs
@@ -78,4 +78,11 @@ mod tests {
         assert_eq!(r_id_one, r_id_two);
         assert_eq!(tourn_one, tourn_two);
     }
+
+    /// Independently tests `squire_lib::identifiers::id_from_item` for consistent behavior across
+    /// platforms.
+    #[test]
+    fn hash_determinism() {
+
+    }
 }

--- a/squire_lib/tests/determinism.rs
+++ b/squire_lib/tests/determinism.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
+    use chrono::{DateTime, Utc};
 
     use squire_tests::get_seed;
 
     use squire_lib::{
         accounts::SquireAccount,
-        identifiers::AdminId,
+        identifiers::{AdminId, TypeId},
         operations::{AdminOp, JudgeOp, TournOp},
         settings::{PairingSetting, TournamentSetting},
     };
@@ -79,10 +79,17 @@ mod tests {
         assert_eq!(tourn_one, tourn_two);
     }
 
+    const DATA_HASH_PAIRS: &[(DateTime<Utc>, &[u8], TypeId<()>)] = &[];
+
     /// Independently tests `squire_lib::identifiers::id_from_item` for consistent behavior across
     /// platforms.
     #[test]
     fn hash_determinism() {
-
+        for &(salt, item, test_hash) in std::hint::black_box(DATA_HASH_PAIRS) {
+            assert_eq!(
+                std::hint::black_box(squire_lib::identifiers::id_from_item(salt, item)),
+                test_hash
+            );
+        }
     }
 }


### PR DESCRIPTION
Replaces the `DefaultHasher` with `DeterministicHasher<FxHasher64>` in `id_from_item` for platform independence, and adds a test in `tests/determinism.rs`. `id_from_list` should probably also be included to mirror changes made in `id_from_item`.