### PR TITLE
Webapp alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ resolver = "2"
 # We exclude the frontend so that we can compile it as part of the compilation
 # of the backend. Otherwise, there is a deadlock. This is ok since the frontend
 # should always be compiled as WASM, so it doesn't share any deps with.
-exclude = ["squire_web",
-]
+exclude = ["squire_web"]
 
 [profile.release]
 lto = true

--- a/squire_sdk/Cargo.toml
+++ b/squire_sdk/Cargo.toml
@@ -78,7 +78,7 @@ gloo-net = { version = "0.3", optional = true }
 gloo-timers = { version = "0.2", features = ["futures"], optional = true }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 getrandom = { version = "0.2", features = ["js"] }
-web-sys = { version = "0.3.61" }
+web-sys = { version = "0.3.61", features = ["Element", "HtmlCollection", "HtmlDialogElement"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio-tungstenite = { version = "0.19.0", optional = true }

--- a/squire_sdk/src/sync/collections.rs
+++ b/squire_sdk/src/sync/collections.rs
@@ -95,19 +95,27 @@ impl OpLog {
         if self.is_empty() {
             return None;
         }
+        println!("Getting slice. Looking for {id}");
         let mut not_found = true;
         let mut ops = self
             .ops
             .iter()
             .rev()
-            .take_while(|op| mem::replace(&mut not_found, op.id != id))
+            .take_while(|op| {
+                println!("Looking at {}. Doesn't match? {}", op.id, op.id != id);
+                let digest = mem::replace(&mut not_found, op.id != id);
+                println!("Continue? {digest}");
+                digest
+            })
             .cloned()
             .collect::<Vec<_>>();
-        if not_found {
-            None
-        } else {
+        if ops.len() < self.len() || ops.last().map(|op| op.id == id).unwrap_or_default() {
+            println!("Operation found. Including {} ops", ops.len());
             ops.reverse();
             Some(OpSlice { ops: ops.into() })
+        } else {
+            println!("Operation not found.");
+            None
         }
     }
 

--- a/squire_sdk/src/sync/manager.rs
+++ b/squire_sdk/src/sync/manager.rs
@@ -187,7 +187,9 @@ impl TournamentManager {
 
     /// Handles an sync request that is forwarded from the backend.
     pub fn handle_forwarded_sync(&mut self, sync: OpSync) -> SyncForwardResp {
-        let Ok(anchor_id) = sync.first_id() else { return SyncForwardResp::Aborted };
+        let Ok(anchor_id) = sync.first_id() else {
+            return SyncForwardResp::Aborted;
+        };
 
         // Ensure the following holds:
         //  Log : known ops | anchor op | common ops
@@ -293,8 +295,12 @@ mod tests {
         assert_eq!(proc.processed.len(), proc_len[1]);
         assert_eq!(proc.to_process.len(), proc_len[2]);
         let link = server.process_sync(proc);
-        let ServerOpLink::Completed(comp) = link.clone() else { panic!() };
-        let SyncCompletion::ForeignOnly(ref ops) = &comp else { panic!() };
+        let ServerOpLink::Completed(comp) = link.clone() else {
+            panic!()
+        };
+        let SyncCompletion::ForeignOnly(ref ops) = &comp else {
+            panic!()
+        };
         assert_eq!(ops.len(), proc_len[0] + proc_len[2]);
         assert_eq!(&ops.last_op().unwrap().op, op);
         assert_eq!(server.log.len(), log_len + proc_len[2]);
@@ -319,7 +325,9 @@ mod tests {
 
         // Client sends update to server
         let link = proc_sync(&mut server, sync, [0, 0, 1], &op);
-        let ServerOpLink::Completed(comp) = link else { panic!() };
+        let ServerOpLink::Completed(comp) = link else {
+            panic!()
+        };
 
         // Server responds to client one
         c1.handle_completion(comp.clone()).unwrap();
@@ -358,7 +366,9 @@ mod tests {
 
         // Client sends update to server
         let link = proc_sync(&mut server, sync, [1, 0, 1], &op);
-        let ServerOpLink::Completed(comp) = link else { panic!() };
+        let ServerOpLink::Completed(comp) = link else {
+            panic!()
+        };
 
         // Server responds to client one
         c1.handle_completion(comp.clone()).unwrap();
@@ -389,7 +399,9 @@ mod tests {
 
             // Client sends update to server
             let link = proc_sync(&mut server, sync, [1, 0, 1], &op);
-            let ServerOpLink::Completed(comp) = link else { panic!() };
+            let ServerOpLink::Completed(comp) = link else {
+                panic!()
+            };
 
             // Server responds to client one
             c1.handle_completion(comp.clone()).unwrap();
@@ -490,8 +502,12 @@ mod tests {
         let link = server.process_sync(proc);
         println!("Server processed sync init...");
         println!("{link:?}\n");
-        let ServerOpLink::Completed(comp) = link else { panic!() };
-        let SyncCompletion::ForeignOnly(ref ops) = &comp else { panic!() };
+        let ServerOpLink::Completed(comp) = link else {
+            panic!()
+        };
+        let SyncCompletion::ForeignOnly(ref ops) = &comp else {
+            panic!()
+        };
         assert_eq!(ops.len(), 2);
         assert_eq!(ops.last_op().unwrap().op, c2_op);
         assert_eq!(server.log.len(), server_op_len + 1);
@@ -520,7 +536,9 @@ mod tests {
         assert_eq!(proc.to_process.len(), 1);
         let link = server.process_sync(proc);
         println!("{link:?}\n");
-        let ServerOpLink::Conflict(conflict) = link else { panic!() };
+        let ServerOpLink::Conflict(conflict) = link else {
+            panic!()
+        };
         assert_eq!(conflict.known.len(), 2);
         assert_eq!(conflict.processed.len(), 0);
         assert_eq!(conflict.to_process.len(), 1);
@@ -530,7 +548,9 @@ mod tests {
         // Server resolves conflict via purging and responses
         let decision = conflict.purge();
         let link = server.handle_decision(decision);
-        let ServerOpLink::Completed(comp) = link else { panic!() };
+        let ServerOpLink::Completed(comp) = link else {
+            panic!()
+        };
         assert_eq!(comp.len(), 2);
         assert_eq!(server.log.len(), 2);
         assert_eq!(server.log.last_op().unwrap().op, c2_op);
@@ -573,8 +593,12 @@ mod tests {
         assert_eq!(proc.to_process.len(), 1);
         let link = server.process_sync(proc);
         println!("{link:?}\n");
-        let ServerOpLink::Completed(comp) = link else { panic!() };
-        let SyncCompletion::ForeignOnly(ref ops) = &comp else { panic!() };
+        let ServerOpLink::Completed(comp) = link else {
+            panic!()
+        };
+        let SyncCompletion::ForeignOnly(ref ops) = &comp else {
+            panic!()
+        };
         assert_eq!(ops.len(), 2);
         assert_eq!(ops.last_op().unwrap().op, op);
         assert_eq!(server.log.len(), 2);
@@ -610,8 +634,12 @@ mod tests {
         assert_eq!(proc.to_process.len(), 1);
         let link = server.process_sync(proc);
         println!("{link:?}\n");
-        let ServerOpLink::Completed(comp) = link else { panic!() };
-        let SyncCompletion::Mixed(ref ops) = &comp else { panic!() };
+        let ServerOpLink::Completed(comp) = link else {
+            panic!()
+        };
+        let SyncCompletion::Mixed(ref ops) = &comp else {
+            panic!()
+        };
         assert_eq!(ops.len(), 3);
         assert_eq!(ops.last_op().unwrap().op, c2_op);
         assert_eq!(server.log.len(), 3);

--- a/squire_sdk/src/sync/messages/chain.rs
+++ b/squire_sdk/src/sync/messages/chain.rs
@@ -67,7 +67,7 @@ impl SyncChain {
         // a Init message and then that message is validated.
         let last = self.links.last().unwrap();
         if msg == &last.0 {
-            return Err(last.1.clone().into());
+            return Err(last.1.clone());
         }
         match msg {
             ClientOpLink::Init(_) => Err(SyncError::AlreadyInitialized.into()),
@@ -81,6 +81,8 @@ impl SyncChain {
 
 #[derive(Debug)]
 pub struct ForwardChain {
+    #[allow(dead_code)]
     init: OpSync,
+    #[allow(dead_code)]
     resp: Option<SyncForwardResp>,
 }

--- a/squire_sdk/src/sync/mod.rs
+++ b/squire_sdk/src/sync/mod.rs
@@ -55,7 +55,10 @@ impl OpSync {
     }
 
     /// Validates the sync against a log. Check id, seed, creator, and len.
-    fn validate(&self, log: &OpLog) -> Result<(), SyncError> {
+    #[allow(dead_code)] // This is a "private" method that is only used by private methods, which
+                        // are only used if "client" or "server are enabled. Its easier to just
+                        // allow "dead_code" here
+    pub(crate) fn validate(&self, log: &OpLog) -> Result<(), SyncError> {
         if self.is_empty() {
             return Err(SyncError::EmptySync);
         }

--- a/squire_sdk/src/sync/processor.rs
+++ b/squire_sdk/src/sync/processor.rs
@@ -101,6 +101,7 @@ impl SyncProcessor {
                 for op in iter {
                     match sync.first_id() {
                         Ok(id) if id == op.id => {
+                            println!("Found a matching Op: {id}! Dropping it from the proc!");
                             let _ = sync.pop_front();
                         }
                         Ok(_) | Err(_) => break,

--- a/squire_web/Dockerfile
+++ b/squire_web/Dockerfile
@@ -1,0 +1,30 @@
+# Compile frontend
+FROM rustlang/rust:nightly AS rust-build
+
+RUN mkdir /app
+WORKDIR /app
+
+# Git clone
+RUN git clone --recursive https://github.com/MonarchDevelopment/SquireCore 
+WORKDIR /app/SquireCore
+RUN git switch wip-web-frontend
+
+# Tools setup
+RUN wget -qO- https://github.com/thedodd/trunk/releases/download/v0.16.0/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+RUN cargo install --locked wasm-bindgen-cli
+RUN rustup target add wasm32-unknown-unknown
+
+# Build
+RUN cargo build --manifest-path squire_web/Cargo.toml --target wasm32-unknown-unknown
+RUN ./trunk build squire_web/index.html
+
+# Setup web server (NGINX)
+FROM nginx:alpine
+
+WORKDIR /usr/share/nginx/html
+RUN rm -rf ./*
+COPY --from=rust-build --chown=nginx /app/SquireCore/squire_web/dist/* .
+
+EXPOSE 80/tcp
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/squire_web/src/tournament/pairings/mod.rs
+++ b/squire_web/src/tournament/pairings/mod.rs
@@ -15,10 +15,9 @@ use yew::{prelude::*, virtual_dom::VNode};
 
 use super::{creator, rounds::SelectedRound, spawn_update_listener};
 use crate::{
-    utils::{console_log, input, TextInput, generic_scroll_vnode, generic_popout_window},
+    utils::{console_log, generic_popout_window, generic_scroll_vnode, input, TextInput},
     CLIENT,
 };
-
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct PairingsWrapper {
@@ -190,14 +189,21 @@ impl Component for PairingsView {
                 true
             }
             PairingsViewMessage::PopoutActiveRounds() => {
-                if (self.active.is_none()) { return false }
-                let scroll_strings = self.active.as_ref().unwrap().iter().map(|ars|{
-                    //let player_list = ars.players.iter().map(|pn|{ 
+                if (self.active.is_none()) {
+                    return false;
+                }
+                let scroll_strings = self.active.as_ref().unwrap().iter().map(|ars| {
+                    //let player_list = ars.players.iter().map(|pn|{
                     //    format!("{}, ", pn)
                     //}).collect();
-                    format!("Round #{}, Table #{} :: {}", ars.round_number, ars.table_number, ars.players.join(", ")) 
+                    format!(
+                        "Round #{}, Table #{} :: {}",
+                        ars.round_number,
+                        ars.table_number,
+                        ars.players.join(", ")
+                    )
                 });
-                let scroll_vnode = generic_scroll_vnode( 90, scroll_strings);
+                let scroll_vnode = generic_scroll_vnode(90, scroll_strings);
                 generic_popout_window(scroll_vnode.clone());
                 false
             }
@@ -246,18 +252,16 @@ impl Component for PairingsView {
                 if (self.names.is_none()) {
                     return false;
                 };
-                let player_id: PlayerId = self.names
-                            .as_ref()
-                            .unwrap()
-                            .iter()
-                            .find_map(|(id, name)| (self.single_bye_input == *name).then_some(*id))
-                            .unwrap_or_default();
+                let player_id: PlayerId = self
+                    .names
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .find_map(|(id, name)| (self.single_bye_input == *name).then_some(*id))
+                    .unwrap_or_default();
                 let tracker = CLIENT.get().unwrap().update_tourn(
                     self.id,
-                    TournOp::AdminOp(
-                        self.admin_id.clone().into(),
-                        AdminOp::GiveBye(player_id),
-                    ),
+                    TournOp::AdminOp(self.admin_id.clone().into(), AdminOp::GiveBye(player_id)),
                 );
                 let send_op_result = self.send_op_result.clone();
                 spawn_local(async move {
@@ -396,8 +400,9 @@ impl PairingsView {
     }
 
     fn view_active_menu(&self, ctx: &Context<Self>) -> Html {
-        let cb_active_popout = ctx.link()
-        .callback(move |_| PairingsViewMessage::PopoutActiveRounds() );
+        let cb_active_popout = ctx
+            .link()
+            .callback(move |_| PairingsViewMessage::PopoutActiveRounds());
         html! {
             <div class="py-5">
                 <div class="overflow-auto py-3 pairings-scroll-box">
@@ -442,11 +447,13 @@ impl PairingsView {
                     <br/>
                     </>
                 })
-            };
-            let cb_single_round = ctx.link()
-            .callback(move |_| PairingsViewMessage::CreateSingleRound() );
-            let cb_single_bye = ctx.link()
-            .callback(move |_| PairingsViewMessage::CreateSingleBye() );
+            }
+            let cb_single_round = ctx
+                .link()
+                .callback(move |_| PairingsViewMessage::CreateSingleRound());
+            let cb_single_bye = ctx
+                .link()
+                .callback(move |_| PairingsViewMessage::CreateSingleBye());
             html! {
                 <div class="py-5">
                     <h2>{ "Create single rounds: " }</h2>

--- a/squire_web/src/tournament/players/selected.rs
+++ b/squire_web/src/tournament/players/selected.rs
@@ -12,7 +12,10 @@ use squire_sdk::{
 use yew::prelude::*;
 
 use super::{PlayerView, PlayerViewMessage};
-use crate::{tournament::rounds::{RoundSummary, RoundProfile}, CLIENT};
+use crate::{
+    tournament::rounds::{RoundProfile, RoundSummary},
+    CLIENT,
+};
 
 /// The set of data needed by the UI to display a player. Should be capable of rendering itself in
 /// HTML.

--- a/squire_web/src/tournament/rounds/input.rs
+++ b/squire_web/src/tournament/rounds/input.rs
@@ -8,7 +8,7 @@ use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
 use super::RoundSummary;
-use crate::{tournament::players::RoundProfile, utils::TextInput};
+use crate::{tournament::rounds::RoundProfile, utils::TextInput};
 
 #[derive(PartialEq, Properties)]
 pub struct RoundFilterInputProps {

--- a/squire_web/src/tournament/rounds/selected.rs
+++ b/squire_web/src/tournament/rounds/selected.rs
@@ -1,4 +1,7 @@
-use std::{collections::{HashMap, HashSet}, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use squire_sdk::{
@@ -67,8 +70,8 @@ impl RoundProfile {
 
     pub fn view(&self) -> Html {
         // TODO: Remove unwrap here
-        let dur_left =
-            ChronoDuration::from_std(self.length + self.extensions).unwrap() - (Utc::now() - self.timer);
+        let dur_left = ChronoDuration::from_std(self.length + self.extensions).unwrap()
+            - (Utc::now() - self.timer);
         html! {
             <>
             <p>

--- a/squire_web/src/tournament/rounds/selected.rs
+++ b/squire_web/src/tournament/rounds/selected.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::{HashMap, HashSet}, time::Duration};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use squire_sdk::{
     model::{
         identifiers::AdminId,
@@ -20,7 +20,86 @@ use super::{
     RoundConfirmationTicker, RoundConfirmationTickerMessage, RoundResultTicker, RoundsView,
     RoundsViewMessage,
 };
-use crate::{tournament::players::RoundProfile, utils::console_log, CLIENT};
+use crate::{utils::console_log, CLIENT};
+
+/// The set of data needed by the UI to display a round. Should be capable of rendering itself in
+/// HTML.
+///
+/// NOTE: Under construction
+#[derive(Debug, PartialEq, Clone)]
+pub struct RoundProfile {
+    pub id: RoundId,
+    pub order: Vec<PlayerId>,
+    pub player_names: HashMap<PlayerId, String>,
+    pub timer: DateTime<Utc>,
+    pub status: RoundStatus,
+    pub results: HashMap<PlayerId, u32>,
+    pub draws: u32,
+    pub confirmations: HashSet<PlayerId>,
+    pub length: std::time::Duration,
+    pub extensions: std::time::Duration,
+}
+impl RoundProfile {
+    pub fn new(tourn: &Tournament, rnd: &Round) -> Self {
+        Self {
+            id: rnd.id,
+            status: rnd.status,
+            order: rnd.players.clone(),
+            player_names: rnd
+                .players
+                .iter()
+                .filter_map(|p| {
+                    tourn
+                        .player_reg
+                        .players
+                        .get(p)
+                        .map(|plyr| (*p, plyr.name.clone()))
+                })
+                .collect(), // This is not a Vec<(PlayerId, String)>. This is a HashMap
+            length: rnd.length,
+            extensions: rnd.extension,
+            timer: rnd.timer,
+            results: rnd.results.clone(),
+            draws: rnd.draws,
+            confirmations: rnd.confirmations.clone(),
+        }
+    }
+
+    pub fn view(&self) -> Html {
+        // TODO: Remove unwrap here
+        let dur_left =
+            ChronoDuration::from_std(self.length + self.extensions).unwrap() - (Utc::now() - self.timer);
+        html! {
+            <>
+            <p>
+            { pretty_print_duration(dur_left) }
+            </p>
+            <ul>
+            {
+                self.order.iter()
+                    // Right now this code is duplicated, however once SelectedRound has more functionality it will be made significantly different. (It will have onclick functionality.)
+                    .map(|(pid)| {
+                        let player_name = self.player_names.get(pid).cloned().unwrap_or_default();
+                        let player_wins = self.results.get(pid).cloned().unwrap_or_default();
+                        let player_confirm = self.confirmations.get(pid).is_some();
+                        html! {
+                            <li>
+                            <div>
+                            { format!( "{player_name}") }
+                            </div>
+                            <div>
+                            { format!( "wins : {player_wins}, confirmed : {player_confirm}") }
+                            </div>
+                            </li>
+                        }
+                    })
+                    .collect::<Html>()
+            }
+            </ul>
+            </>
+        }
+    }
+}
 
 /// Message to be passed to the selected round
 #[derive(Debug, PartialEq, Clone)]
@@ -348,5 +427,16 @@ impl RoundUpdater {
             </div>
             </>
         }
+    }
+}
+
+fn pretty_print_duration(dur: ChronoDuration) -> String {
+    let hours = dur.num_hours();
+    let mins = dur.num_minutes().abs();
+    let secs = dur.num_seconds().abs();
+    if hours >= 0 {
+        format!("Time left: {}:{}:{}", hours.abs(), mins % 60, secs % 60)
+    } else {
+        format!("Over time: {}:{}:{}", hours.abs(), mins % 60, secs % 60)
     }
 }

--- a/squire_web/src/tournament/standings/mod.rs
+++ b/squire_web/src/tournament/standings/mod.rs
@@ -3,9 +3,12 @@ use web_sys::window;
 use yew::{prelude::*, virtual_dom::VNode};
 
 use self::_StandingsPopoutProps::display_vnode;
-use crate::{tournament::standings, CLIENT, utils::{console_log, generic_scroll_vnode, generic_popout_window}};
-
 use super::players::scroll;
+use crate::{
+    tournament::standings,
+    utils::{console_log, generic_popout_window, generic_scroll_vnode},
+    CLIENT,
+};
 
 #[derive(Properties, PartialEq)]
 struct StandingsPopoutProps {
@@ -69,10 +72,12 @@ impl Component for StandingsView {
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             StandingsMessage::SpawnPopout(num) => {
-                let scroll_strings = self.standings.standings.iter().map(|(i, s)|{
-                    format!("{i} : {s}")
-                });
-                self.scroll_vnode = Some(generic_scroll_vnode( 120, scroll_strings));
+                let scroll_strings = self
+                    .standings
+                    .standings
+                    .iter()
+                    .map(|(i, s)| format!("{i} : {s}"));
+                self.scroll_vnode = Some(generic_scroll_vnode(120, scroll_strings));
                 generic_popout_window(self.scroll_vnode.clone().unwrap());
             }
             StandingsMessage::StandingsQueryReady(data) => {

--- a/squire_web/src/utils/mod.rs
+++ b/squire_web/src/utils/mod.rs
@@ -1,10 +1,10 @@
 pub mod input;
-pub mod requests;
 pub mod popout;
+pub mod requests;
 
 pub use input::*;
-pub use requests::*;
 pub use popout::*;
+pub use requests::*;
 use wasm_bindgen::__rt::RefMut;
 
 /// A wrapper around web_sys console log_1

--- a/squire_web/src/utils/mod.rs
+++ b/squire_web/src/utils/mod.rs
@@ -1,8 +1,10 @@
 pub mod input;
 pub mod requests;
+pub mod popout;
 
 pub use input::*;
 pub use requests::*;
+pub use popout::*;
 use wasm_bindgen::__rt::RefMut;
 
 /// A wrapper around web_sys console log_1

--- a/squire_web/src/utils/popout.rs
+++ b/squire_web/src/utils/popout.rs
@@ -1,7 +1,6 @@
 use web_sys::window;
 use yew::{prelude::*, virtual_dom::VNode};
 
-
 #[function_component]
 fn GeneralPopout(props: &GeneralPopoutProps) -> Html {
     props.display_vnode.clone()
@@ -27,8 +26,9 @@ pub fn generic_popout_window(vnode: VNode) {
         });
 }
 
-pub fn generic_scroll_vnode<I>(vert_scroll_time: u32, string_vec: I) -> Html 
-where I : Iterator<Item = String>
+pub fn generic_scroll_vnode<I>(vert_scroll_time: u32, string_vec: I) -> Html
+where
+    I: Iterator<Item = String>,
 {
     html! {
         <html>

--- a/squire_web/src/utils/popout.rs
+++ b/squire_web/src/utils/popout.rs
@@ -1,0 +1,84 @@
+use web_sys::window;
+use yew::{prelude::*, virtual_dom::VNode};
+
+
+#[function_component]
+fn GeneralPopout(props: &GeneralPopoutProps) -> Html {
+    props.display_vnode.clone()
+}
+#[derive(Properties, PartialEq)]
+pub struct GeneralPopoutProps {
+    pub display_vnode: VNode,
+}
+
+pub fn generic_popout_window(vnode: VNode) {
+    window()
+        .and_then(|w| w.open().ok().flatten())
+        .and_then(|new_w_o| new_w_o.document())
+        .and_then(|doc| doc.get_elements_by_tag_name("html").get_with_index(0))
+        .map(|r| {
+            yew::Renderer::<GeneralPopout>::with_root_and_props(
+                r,
+                GeneralPopoutProps {
+                    display_vnode: vnode,
+                },
+            )
+            .render()
+        });
+}
+
+pub fn generic_scroll_vnode<I>(vert_scroll_time: u32, string_vec: I) -> Html 
+where I : Iterator<Item = String>
+{
+    html! {
+        <html>
+            <head>
+                <title>{ "Standings!" }</title>
+                <style>{format!("
+            html, body {{
+                overflow: hidden;
+            }}
+            .scroll_holder {{
+                overflow: hidden;
+                box-sizing: border-box;
+                position: relative;
+                box-sizing: border-box;
+            }}
+            .vert_scroller {{
+                position: relative;
+                box-sizing: border-box;
+                animation: vert_scroller {}s linear infinite;
+            }}
+            .scroll_item {{
+                display: block;
+                font-size: 3em;
+                font-family: Arial, Helvetica, sans-serif;
+                margin: auto;
+                height: 2em;
+                text-align: center;
+            }}
+            @keyframes vert_scroller {{
+                0%   {{ top:  120vh }}
+                100% {{ top: -100% }}
+            }}
+            ", vert_scroll_time)}</style>
+            </head>
+            <body>
+                <div class="scroll_holder">
+                    <div class="vert_scroller">
+                    {
+                            string_vec
+                            .map(|(s)|
+                                html! {
+                                    <div class="scroll_item">
+                                        <p>{ format!("#{s}") }</p>
+                                    </div>
+                                })
+                            .collect::<Html>()
+                    }
+                    </div>
+                </div>
+            </body>
+        </html>
+    }
+}


### PR DESCRIPTION
This PR marks the first alpha version of the webapp. This MVP version will support all tournament operations other than deck operations. New tournaments will be persisted to the backend's Mongo DB instance. All clients connected to the same tournament will receive updates from each other as they happen, and the MVP will be capable of running a tournament from start to finish.